### PR TITLE
fix: :bug: Change action so that it uses the correct trigger

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,7 +1,7 @@
 name: "Conventional Commit PR Title"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
pull_request_target = the github repo that the workflow lives in
pull_request = the github repo running the workflow